### PR TITLE
Add options with update

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -32,6 +32,22 @@
       else
         puts "unable to remove space: #{c.error}"
       end
+
+      #########
+      # Pages #
+      #########
+      page = confluence.get_page('space name', 'page name')
+      if page
+        puts "page id: #{page}"
+
+        page['content'] = page['content'] + '<br /><h3>test message :)</h3>'
+        options = {'minorEdit' => 'false', 'versionComment' => 'add test message'}
+        if confluence.update_page(page, options)
+            puts 'update success'
+        else
+            puts 'update failed'
+        end
+      end
       
       #########
       # Users #

--- a/lib/confluence-client.rb
+++ b/lib/confluence-client.rb
@@ -270,8 +270,9 @@ module Confluence # :nodoc:
     #
     # Params:
     # +page+:: Page Hash
-    def update_page(page)
-      updatePage(page, {})
+    # +options+:: Options Hash
+    def update_page(page, options = {})
+      updatePage(page, options)
       return ok?
       #return true if ok?
       #nil


### PR DESCRIPTION
Add arg 'options' to update_page method because i'd like to use 'minorEidt' option.
- see [Remote Confluence Data Objects - Atlassian Developers](https://developer.atlassian.com/confdev/confluence-rest-api/confluence-xml-rpc-and-soap-apis/remote-confluence-data-objects#RemoteConfluenceDataObjects-pageupdateoptionsPageUpdateOptions)
